### PR TITLE
compatible Android 5.x and add a nativeDecodeFile method impl

### DIFF
--- a/webp-android-backport-library/jni/webpbackport/android_backport_webp.cpp
+++ b/webp-android-backport-library/jni/webpbackport/android_backport_webp.cpp
@@ -14,21 +14,27 @@ namespace lang {
 
 jclass_NullPointerException::jclass_NullPointerException(JNIEnv* jniEnv)
 {
-	jclassRef = jniEnv->FindClass("java/lang/NullPointerException");
+	jclass temp = jniEnv->FindClass("java/lang/NullPointerException");
+	jclassRef = (jclass)jniEnv->NewGlobalRef(temp);
+	jniEnv->DeleteLocalRef(temp);
 	assert(jclassRef == 0);
 }
 jclass_NullPointerException* NullPointerException = 0;
 
 jclass_IllegalArgumentException::jclass_IllegalArgumentException(JNIEnv* jniEnv)
 {
-	jclassRef = jniEnv->FindClass("java/lang/IllegalArgumentException");
+	jclass temp = jniEnv->FindClass("java/lang/IllegalArgumentException");
+	jclassRef = (jclass)jniEnv->NewGlobalRef(temp);
+	jniEnv->DeleteLocalRef(temp);
 	assert(jclassRef == 0);
 }
 jclass_IllegalArgumentException* IllegalArgumentException = 0;
 
 jclass_RuntimeException::jclass_RuntimeException(JNIEnv* jniEnv)
 {
-	jclassRef = jniEnv->FindClass("java/lang/RuntimeException");
+	jclass temp = jniEnv->FindClass("java/lang/RuntimeException");
+	jclassRef = (jclass)jniEnv->NewGlobalRef(temp);
+	jniEnv->DeleteLocalRef(temp);
 	assert(jclassRef == 0);
 }
 jclass_RuntimeException* RuntimeException = 0;
@@ -43,7 +49,9 @@ jclass_Bitmap* Bitmap = 0;
 jclass_Bitmap::jclass_Bitmap(JNIEnv* jniEnv)
 	: Config(jniEnv)
 {
-	jclassRef = jniEnv->FindClass("android/graphics/Bitmap");
+	jclass temp = jniEnv->FindClass("android/graphics/Bitmap");
+	jclassRef = (jclass)jniEnv->NewGlobalRef(temp);
+	jniEnv->DeleteLocalRef(temp);
 	assert(jclassRef == 0);
 
 	createBitmap = jniEnv->GetStaticMethodID(jclassRef,
@@ -53,7 +61,9 @@ jclass_Bitmap::jclass_Bitmap(JNIEnv* jniEnv)
 }
 jclass_Bitmap::jclass_Config::jclass_Config(JNIEnv* jniEnv)
 {
-	jclassRef = jniEnv->FindClass("android/graphics/Bitmap$Config");
+	jclass temp = jniEnv->FindClass("android/graphics/Bitmap$Config");
+	jclassRef = (jclass)jniEnv->NewGlobalRef(temp);
+	jniEnv->DeleteLocalRef(temp);
 	assert(jclassRef == 0);
 
 	ARGB_8888 = jniEnv->GetStaticFieldID(jclassRef,
@@ -69,7 +79,9 @@ jclass_BitmapFactory::jclass_BitmapFactory(JNIEnv* jniEnv)
 }
 jclass_BitmapFactory::jclass_Options::jclass_Options(JNIEnv* jniEnv)
 {
-	jclassRef = jniEnv->FindClass("android/graphics/BitmapFactory$Options");
+	jclass temp = jniEnv->FindClass("android/graphics/BitmapFactory$Options");
+	jclassRef = (jclass)jniEnv->NewGlobalRef(temp);
+	jniEnv->DeleteLocalRef(temp);
 	assert(jclassRef == 0);
 	
 	inJustDecodeBounds = jniEnv->GetFieldID(jclassRef,

--- a/webp-android-backport-library/src/android/backport/webp/WebPFactory.java
+++ b/webp-android-backport-library/src/android/backport/webp/WebPFactory.java
@@ -19,6 +19,15 @@ public final class WebPFactory {
 	 * @return Decoded bitmap
 	 */
 	public static native Bitmap nativeDecodeByteArray(byte[] data, BitmapFactory.Options options);
+
+	/**
+     * Decodes file to bitmap
+     *
+     * @param path    WebP file path
+     * @param options Options to control decoding. Accepts null
+     * @return Decoded bitmap
+     */
+    private static native Bitmap nativeDecodeFile(String path, BitmapFactory.Options options);
 	
 	/**
 	 * Encodes bitmap into byte array


### PR DESCRIPTION
1. fix a crash bug when webpbackport run on Android 5.0 devices.
2. 	add a nativeDecodeFile method impl.